### PR TITLE
add css markdownbody

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -16,7 +16,7 @@
         <li class="child" v-for="issue in filterIssues" :key="issue.id" @click="listClick" :data-index="issue.id">
           {{ issue.title }}
           <div v-if="isShow == issue.id" > 
-            <div class="markdown-body" v-html="compiledMarkdown(issue.content)"></div>
+            <div class="markdown-body issue-detail" v-html="compiledMarkdown(issue.content)"></div>
             <parentul v-bind:issue_child = "issue.children" ></parentul>
           </div>
         </li>
@@ -146,6 +146,11 @@ export default {
         background-color:#fdfdff;
         min-height: 200px;
         border: 1px solid lightgray
+      }
+      .issue-detail {
+        padding: 5px;
+        text-align: start;
+        font-size: 0.5em;
       }
     }
   }


### PR DESCRIPTION
# what
issueの詳細部分のcss見た目を整え直す。

- 大きさ
- 余白

# before
<img width="250" alt="スクリーンショット 2020-09-06 15 45 39" src="https://user-images.githubusercontent.com/15213843/92319919-63c71080-f058-11ea-9170-54feacaf6fca.png">

# after
<img width="251" alt="スクリーンショット 2020-09-06 15 45 16" src="https://user-images.githubusercontent.com/15213843/92319917-5ca00280-f058-11ea-8106-b20c318ab5fd.png">
